### PR TITLE
fix: add "&nbsp;" for displaying text with space between multi child-…

### DIFF
--- a/src/features/chat/messages/components/message-item/message-item-forward.tsx
+++ b/src/features/chat/messages/components/message-item/message-item-forward.tsx
@@ -39,7 +39,7 @@ export const MessageItemForward = ({
       <div className="order-neutral-100 ml-auto w-fit rounded-2xl border p-2">
         <div>
           <div className="text-sm">
-            <span className="italic text-neutral-400">Forward from</span>
+            <span className="italic text-neutral-400">Forward from&nbsp;</span>
             <Wrapper room={message.room!}>
               <span className="text-primary">{displayForwardFrom}</span>
             </Wrapper>

--- a/src/features/chat/messages/components/message-item/message-item-system.tsx
+++ b/src/features/chat/messages/components/message-item/message-item-system.tsx
@@ -11,14 +11,15 @@ export const MessageItemSystem = ({
   isMe,
 }: MessageItemSystemProps) => {
   const { changeTab } = useRoomSidebarTabs();
+  const messageContent = `${
+    isMe ? 'You' : message.sender.name
+  } ${message?.content}`;
   return (
     <div className="mx-auto">
       <span className="text-sm font-light text-neutral-500">
-        {isMe ? 'You' : message.sender.name}
-        {' ' + message.content}
-
+        {messageContent}
         {message.targetUsers?.map((user, index) => {
-          return index === 0 ? ' ' + user.name : ', ' + user.name;
+          return !index ? ' ' + user.name : ', ' + user.name;
         })}
       </span>
       {message.content.includes('pin') &&
@@ -27,7 +28,7 @@ export const MessageItemSystem = ({
             onClick={() => changeTab('pinned')}
             className="cursor-pointer text-sm text-primary active:text-primary-700 md:hover:text-primary-600"
           >
-            View
+            &nbsp;View
           </span>
         )}
     </div>

--- a/src/features/notification/components/toast-notification.tsx
+++ b/src/features/notification/components/toast-notification.tsx
@@ -23,7 +23,7 @@ export const ToastNotification = ({
       <div className="flex w-full">
         <span>
           Are you sure? Without notifications, it’s much harder for your team to
-          reach you.
+          reach you.&nbsp;
           <TextUnderlineClickAble onClick={onEnable}>
             Enable notifications
           </TextUnderlineClickAble>
@@ -42,7 +42,7 @@ export const ToastNotification = ({
   return (
     <div className="flex w-full">
       <span>
-        Middo needs your permission to
+        {`Middo needs your permission to `}
         <TextUnderlineClickAble onClick={onEnable}>
           enable notifications
         </TextUnderlineClickAble>


### PR DESCRIPTION
# add "&nbsp;" for displaying text with space between multi child-texts