### PR TITLE
Cherry: add missing translation shortcuts

### DIFF
--- a/src/components/data-entry/search-input.tsx
+++ b/src/components/data-entry/search-input.tsx
@@ -5,6 +5,7 @@ import {
   InputHTMLAttributes,
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -46,6 +47,11 @@ export const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
         inputRef.current?.focus();
       },
     );
+    useEffect(() => {
+      if (currentSide === 'individual') {
+        inputRef.current?.focus();
+      }
+    }, [currentSide]);
     useImperativeHandle(
       ref,
       () => ({
@@ -65,7 +71,7 @@ export const SearchInput = forwardRef<SearchInputRef, SearchInputProps>(
             ref={inputRef}
             type="text"
             {...props}
-            autoFocus
+            // autoFocus
             onChange={(e) => {
               props.onChange?.(e);
               setValue(e.target.value);

--- a/src/features/translate/components/editor/translate-editor.tsx
+++ b/src/features/translate/components/editor/translate-editor.tsx
@@ -93,6 +93,9 @@ export const TranslateEditor = ({
   useKeyboardShortcut([SHORTCUTS.COPY_INPUT], () => {
     copy();
   });
+  useKeyboardShortcut([SHORTCUTS.TEXT_TO_SPEECH_INPUT], () => {
+    speak();
+  });
   useEffect(() => {
     if (sourceTranslateResult && !text) {
       setValue(sourceTranslateResult);

--- a/src/features/translate/components/editor/translate-result.tsx
+++ b/src/features/translate/components/editor/translate-result.tsx
@@ -35,6 +35,10 @@ export const TranslateResult = ({
   useKeyboardShortcut([SHORTCUTS.TRANSLATED_COPY], () => {
     copy();
   });
+  useKeyboardShortcut([SHORTCUTS.TRANSLATED_TEXT_TO_SPEECH], () => {
+    speak();
+  });
+  
   return (
     <TranslateEditorWrapper
       className={cn(

--- a/src/hooks/use-keyboard-shortcuts.ts
+++ b/src/hooks/use-keyboard-shortcuts.ts
@@ -1,20 +1,18 @@
-"use client";
+'use client';
 
-import { useShortcutListenStore } from "@/stores/shortcut-listen.store";
-import { useTranslateStore } from "@/stores/translate.store";
-import { MAPPED_MAC_KEYS, MAPPED_WIN_KEYS } from "@/types/shortcuts";
-import { useEffect, useState } from "react";
+import { useShortcutListenStore } from '@/stores/shortcut-listen.store';
+import { useTranslateStore } from '@/stores/translate.store';
+import { MAPPED_MAC_KEYS, MAPPED_WIN_KEYS } from '@/types/shortcuts';
+import { useEffect, useState } from 'react';
 
-type Key = "shift" | string;
+type Key = 'shift' | string;
 
 export const useKeyboardShortcut = (
   keysSet: Array<Key[]>,
   callback: (event?: KeyboardEvent, matchedKeys?: string[]) => void,
   ignoreFocusingInputs?: boolean,
 ) => {
-  const {
-    isFocused
-  } = useTranslateStore();
+  const { isFocused } = useTranslateStore();
   const { allowShortcutListener } = useShortcutListenStore();
   const [isMacOS, setIsMacOS] = useState(false);
 
@@ -27,33 +25,49 @@ export const useKeyboardShortcut = (
   }, []);
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if ((allowShortcutListener || ignoreFocusingInputs) || ((isFocused || !allowShortcutListener) && event?.ctrlKey)
+      if (
+        allowShortcutListener ||
+        ignoreFocusingInputs ||
+        ((isFocused || !allowShortcutListener) && event?.ctrlKey)
       ) {
+        // console.log('event.key', event.key)
         keysSet?.some((keys) => {
-          if (keys?.every(
-            (key) => {
-              const keyByOS = (isMacOS ? MAPPED_MAC_KEYS[key] : MAPPED_WIN_KEYS[key]) || key;
-              const isMatched = (keyByOS?.toLowerCase() === "shift" && event?.shiftKey) ||
-                (keyByOS?.toLowerCase() === "ctrl" && event?.ctrlKey) ||
-                (keyByOS?.toLowerCase() === "alt" && event?.altKey) ||
-                (keyByOS?.toLowerCase() === "meta" && event?.metaKey) ||
-                (typeof keyByOS === "string" && event?.key?.toLowerCase() === keyByOS?.toLowerCase());
+          if (
+            keys?.every((key) => {
+              const keyByOS =
+                (isMacOS ? MAPPED_MAC_KEYS[key] : MAPPED_WIN_KEYS[key]) || key;
+              const isMatched =
+                (keyByOS?.toLowerCase() === 'shift' && event?.shiftKey) ||
+                (keyByOS?.toLowerCase() === 'ctrl' && event?.ctrlKey) ||
+                (keyByOS?.toLowerCase() === 'alt' && event?.altKey) ||
+                (keyByOS?.toLowerCase() === 'meta' && event?.metaKey) ||
+                (typeof keyByOS === 'string' &&
+                  event?.key?.toLowerCase() === keyByOS?.toLowerCase()) ||
+                (isMacOS &&
+                  MAPPED_WIN_KEYS[key] &&
+                  MAPPED_WIN_KEYS[key]?.toLowerCase() ===
+                    event?.key?.toLowerCase());
               return isMatched;
-            }
-          )
+            })
           ) {
             event?.preventDefault();
             callback(event, keys);
             return true;
           }
-        }
-        )
+        });
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener('keydown', handleKeyDown);
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [keysSet, callback, isMacOS, isFocused, allowShortcutListener, ignoreFocusingInputs]);
-  return { isMacOS }
+  }, [
+    keysSet,
+    callback,
+    isMacOS,
+    isFocused,
+    allowShortcutListener,
+    ignoreFocusingInputs,
+  ]);
+  return { isMacOS };
 };

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -77,7 +77,7 @@ export enum SCTranslation {
     
     [SCTranslation.TEXT_TO_SPEECH_INPUT]: ['ctrl_or_alt', 'z'],
     [SCTranslation.COPY_INPUT]: ['ctrl_or_alt', 'x'],
-    [SCTranslation.TRANSLATED_TEXT_TO_SPEECH]: ['ctrl_or_alt', '/'],
+    [SCTranslation.TRANSLATED_TEXT_TO_SPEECH]: ['ctrl_or_alt', ','],
     [SCTranslation.TRANSLATED_COPY]: ['ctrl_or_alt', '.'],
     [SCTranslation.COPY_ALL_TEXT]: ['ctrl_or_alt', 'a'],
     [SCTranslation.COPY_IMAGE]: ['ctrl_or_alt', 'i'],


### PR DESCRIPTION
### Description: cherry pick the commits for

- turn off search autoFocus, only focus after change to 'individual'
- Add missing shortcuts off translation
- Fix the bug: shortcuts not working on `Middo call` on Safari