### PR TITLE
```text

### DIFF
--- a/src/app/(main-layout)/(protected)/spaces/[spaceId]/scripts/_components/script-creation/schema.ts
+++ b/src/app/(main-layout)/(protected)/spaces/[spaceId]/scripts/_components/script-creation/schema.ts
@@ -59,6 +59,7 @@ export const createChatScriptSchema = z.object({
           z.object({
             id: z.string(),
             type: z.string(),
+            parentNode: z.string().optional(),
             data: z
               .object({
                 label: z.string().optional(),


### PR DESCRIPTION
feat: Add optional parentNode field to createChatScriptSchema

This commit adds an optional `parentNode` field to the `createChatScriptSchema` in the `script-creation/schema.ts` file. This field allows for more flexibility in defining the parent node of a chat script.