### PR TITLE
feat: Filter joined members in report picker dropdown

### DIFF
--- a/src/app/(main-layout)/(protected)/spaces/[spaceId]/statistics/_components/report/report-header/report-picker-member.tsx
+++ b/src/app/(main-layout)/(protected)/spaces/[spaceId]/statistics/_components/report/report-header/report-picker-member.tsx
@@ -30,10 +30,12 @@ const ReportPickerMember = ({}: ReportPickerMemberProps) => {
     value: null,
   };
   const options = useMemo(() => {
-    return (space?.members.map((member) => ({
-      name: member.email,
-      value: member._id,
-    })) || []) as DropdownOption[];
+    return (space?.members
+      ?.filter(({ status }) => status === 'joined')
+      ?.map((member) => ({
+        name: member.email,
+        value: member._id,
+      })) || []) as DropdownOption[];
   }, [space]);
   const searchParams = useSearchParams();
   const current = new URLSearchParams(


### PR DESCRIPTION
This commit updates the `ReportPickerMember` component to filter out members who have not joined the space. It ensures that only joined members are displayed in the dropdown options, improving the user experience when selecting a member for the report.