### PR TITLE
Refactor video layout and focus video item

### DIFF
--- a/src/features/call/video-call/components/layouts/p2p-layout.tsx
+++ b/src/features/call/video-call/components/layouts/p2p-layout.tsx
@@ -30,10 +30,7 @@ const P2PLayout = () => {
     return (
         <div className="relative flex w-full h-full p-1">
             <div className="flex h-full w-full relative">
-                {participantPin && <FocusVideoItem participant={participantPin} isAllowChangeView={false}/>}
-                {participantPin && <div className="hidden"> 
-                    <VideoItem participant={participantPin} />
-                </div>}
+                {participantPin && <FocusVideoItem isLoadAudio={true} participant={participantPin} isAllowChangeView={false}/>}
             </div>
             <ParticipantsBar participants={anotherParticipants}/>
         </div>

--- a/src/features/call/video-call/components/video/focus-video-item.tsx
+++ b/src/features/call/video-call/components/video/focus-video-item.tsx
@@ -19,10 +19,13 @@ import ParticipantInVideoCall from '@/features/call/interfaces/participant';
 interface FocusVideoItemProps {
   participant: ParticipantInVideoCall;
   isAllowChangeView?: boolean;
+  isLoadAudio?: boolean;
 }
-const FocusVideoItem = ({ participant, isAllowChangeView = true }: FocusVideoItemProps) => {
-  const {t} = useTranslation('common')
-  
+const FocusVideoItem = ({ 
+  participant, 
+  isAllowChangeView = true,
+  isLoadAudio = false
+}: FocusVideoItemProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const parentRef = useRef<HTMLElement>(null);
   const { isTurnOnCamera } = useLoadStream(participant, videoRef);
@@ -98,7 +101,7 @@ const FocusVideoItem = ({ participant, isAllowChangeView = true }: FocusVideoIte
           isTurnOnCamera ? '' : 'hidden',
         )}
         autoPlay
-        muted
+        muted={participant?.isMe || !isLoadAudio}
         playsInline
         controls={false}
       ></video>


### PR DESCRIPTION
This commit refactors the video layout in the P2PLayout component and the FocusVideoItem component. It removes unnecessary code and adds a new prop "isLoadAudio" to the FocusVideoItem component. The "isLoadAudio" prop is used to control whether the audio should be loaded for the participant's video.